### PR TITLE
[Feat/#115] 프론트의 vault-data(role-id, secret-id) API 생성 및 vault.js에 API 연동

### DIFF
--- a/back/transcendence/urls.py
+++ b/back/transcendence/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
+from transcendence import views 
 import sys
 import os
 from vault import *
@@ -26,4 +27,6 @@ urlpatterns = [
     path(getSecretValue('back/BACK_API_ACCOUNT'), include('accounts.urls')),
     path(getSecretValue('back/BACK_API_SOCIAL_ACCOUNTS'), include('social_accounts.urls')),
     path(getSecretValue('back/BACK_API_FRIENDS'), include('friends.urls')),
+    # path(getSecretValue('back/BACK_API_VAULT'), views.get_vault_data, name='get_vault_data'),
+    path('api/vault/', views.get_vault_data, name='get_vault_data'),
 ]

--- a/back/transcendence/views.py
+++ b/back/transcendence/views.py
@@ -1,0 +1,25 @@
+import os
+import json
+from django.http import JsonResponse
+
+def get_vault_data(request):
+    # vite의 볼륨 경로
+    role_id_path = '/usr/src/app/approle/front/role-id.json'
+    secret_id_path = '/usr/src/app/approle/front/secret-id.json'
+
+    try:
+        # JSON 파일 읽기
+        with open(role_id_path, 'r') as role_file:
+            role_data = json.load(role_file)
+        with open(secret_id_path, 'r') as secret_file:
+            secret_data = json.load(secret_file)
+
+        # role-id와 secret-id 반환
+        return JsonResponse({
+            'role_id': role_data.get('data', {}).get('role_id', ''),
+            'secret_id': secret_data.get('data', {}).get('secret_id', '')
+        })
+    except FileNotFoundError as e:
+        return JsonResponse({'error': 'File not found', 'message': str(e)}, status=404)
+    except Exception as e:
+        return JsonResponse({'error': 'An error occurred', 'message': str(e)}, status=500)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,7 @@ services:
       - static-data:/vol/static
       - media-data:/vol/media
       - ./volumes/vault-data/approle/back:/usr/src/app/approle
+      - ./volumes/vault-data/approle/front:/usr/src/app/approle/front
     networks:
       - transcendence
   

--- a/front/src/vault.js
+++ b/front/src/vault.js
@@ -1,35 +1,100 @@
 import axios from 'axios';
 
-const VAULT_ADDR = "https://localhost:443";
+const VAULT_ADDR = "https://localhost:443"; // Vault 서버 주소
+const DJANGO_API_URL = "http://localhost:8000/api/vault/"; // Django API URL
 
-export async function getVaultToken() {
-    const roleId = "b7cfeb48-28fb-8ad9-848f-7bf6307ce250";
-    const secretId = "a7da42dd-9ddd-3bc9-b61d-c4a4a0bc2e4b";
-
+/**
+ * Django API에서 role-id와 secret-id 가져오기
+ */
+async function fetchVaultData() {
     try {
-        const response = await axios.post(`${VAULT_ADDR}/v1/auth/approle/login`, {
-            role_id: roleId,
-            secret_id: secretId
-        });
-        return response.data.auth.client_token;
+        const response = await axios.get(DJANGO_API_URL);
+        return response.data; // { role_id, secret_id } 반환
     } catch (error) {
-        console.error('Failed to get Vault token:', error);
+        console.error("Failed to fetch Vault data from Django API:", error.message);
         throw error;
     }
 }
 
+/**
+ * Vault에서 AppRole 로그인 토큰 가져오기
+ */
+export async function getVaultToken() {
+    try {
+        // Django API에서 role-id와 secret-id 가져오기
+        const { role_id, secret_id } = await fetchVaultData();
+
+        console.log("Role ID (from API):", role_id);
+        console.log("Secret ID (from API):", secret_id);
+
+        // Vault 서버에 로그인 요청
+        const response = await axios.post(`${VAULT_ADDR}/v1/auth/approle/login`, {
+            role_id,
+            secret_id,
+        });
+
+        return response.data.auth.client_token; // Vault 토큰 반환
+    } catch (error) {
+        console.error("Failed to get Vault token:", error.message);
+        throw error;
+    }
+}
+
+/**
+ * Vault에서 특정 경로의 비밀값 가져오기
+ * @param {string} secretPath - 비밀값이 저장된 Vault의 경로
+ */
 export async function getSecretValue(secretPath) {
     try {
         const token = await getVaultToken();
+
+        // Vault에서 비밀값 가져오기
         const response = await axios.get(`${VAULT_ADDR}/v1/transcendence/data/${secretPath}`, {
-            headers: { 'X-Vault-Token': token }
+            headers: { "X-Vault-Token": token },
         });
-        return response.data.data.data.envvalue;
+
+        return response.data.data.data.envvalue; // 비밀값 반환
     } catch (error) {
-        console.error('Failed to get secret value:', error);
+        console.error("Failed to get secret value:", error.message);
         throw error;
     }
 }
+
+
+
+
+
+
+// const VAULT_ADDR = "https://localhost:443";
+
+// export async function getVaultToken() {
+//     const roleId = "b7cfeb48-28fb-8ad9-848f-7bf6307ce250";
+//     const secretId = "a7da42dd-9ddd-3bc9-b61d-c4a4a0bc2e4b";
+
+//     try {
+//         const response = await axios.post(`${VAULT_ADDR}/v1/auth/approle/login`, {
+//             role_id: roleId,
+//             secret_id: secretId
+//         });
+//         return response.data.auth.client_token;
+//     } catch (error) {
+//         console.error('Failed to get Vault token:', error);
+//         throw error;
+//     }
+// }
+
+// export async function getSecretValue(secretPath) {
+//     try {
+//         const token = await getVaultToken();
+//         const response = await axios.get(`${VAULT_ADDR}/v1/transcendence/data/${secretPath}`, {
+//             headers: { 'X-Vault-Token': token }
+//         });
+//         return response.data.data.data.envvalue;
+//     } catch (error) {
+//         console.error('Failed to get secret value:', error);
+//         throw error;
+//     }
+// }
 
 
 


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #115 

## ✅ What Did You Do
- [x] API 생성 (/api/vault)
- [x] vault.js에서 role-id, secret-id를 패치하게끔 연동

***

## 🎸 ETC
브라우저에서 fs 사용을 직접적으로 못하면서 생기는 문제 해결하기

vault-data(role-id, secret-id)를 제공하는 API 생성 후
vault.js에서 role-id, secret-id를 패치하게끔 연동