### PR TITLE
[Feat/#124] /edit_profile 페이지 API 연동(back에서 목데이터로 테스트)

### DIFF
--- a/back/accounts/models.py
+++ b/back/accounts/models.py
@@ -65,6 +65,30 @@ class User(AbstractBaseUser, PermissionsMixin):
             'refresh': str(token),
         }
     
+    def get_profile_data(self):
+        """
+        연결된 UserProfile 데이터를 반환.
+        """
+        try:
+            profile = self.userprofile
+            return {
+                "username": self.username,
+                "nickname": profile.nickname,
+                "first_name": self.first_name,
+                "last_name": self.last_name,
+                "email": self.email,
+                "profile_image": self.profile_image.url if self.profile_image else None,
+            }
+        except UserProfile.DoesNotExist:
+            return {
+                "username": self.username,
+                "nickname": None,
+                "first_name": self.first_name,
+                "last_name": self.last_name,
+                "email": self.email,
+                "profile_image": self.profile_image.url if self.profile_image else None,
+            }
+    
 class OTP(models.Model):
     """
     사용자 인증을 위한 One-Time Password 모델.

--- a/back/accounts/serializers.py
+++ b/back/accounts/serializers.py
@@ -39,6 +39,20 @@ class RegisterSerializer(serializers.ModelSerializer):
         UserStats.objects.create(user=user)
         return user
 
+class ExtendedProfileSerializer(serializers.ModelSerializer):
+    """
+    User 및 UserProfile 데이터를 포함하는 Serializer.
+    """
+    username = serializers.CharField(source="user.username", read_only=True)
+    email = serializers.EmailField(source="user.email", read_only=True)
+    first_name = serializers.CharField(source="user.first_name", required=False)
+    last_name = serializers.CharField(source="user.last_name", required=False)
+    profile_image = serializers.ImageField(source="user.profile_image", required=False)
+
+    class Meta:
+        model = UserProfile
+        fields = ["nickname", "username", "email", "first_name", "last_name", "profile_image"]
+
 class ProfileSerializer(serializers.ModelSerializer):
     """
     사용자 프로필 데이터를 처리하는 Serializer.

--- a/back/accounts/views.py
+++ b/back/accounts/views.py
@@ -1,10 +1,12 @@
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 from .models import User, UserProfile, UserStats, OTP
-from .serializers import RegisterSerializer, ProfileSerializer, UserStatsSerializer, LogoutSerializer, LoginSerializer, VerifyEmailSerializer
+from .serializers import RegisterSerializer, ExtendedProfileSerializer, ProfileSerializer, UserStatsSerializer, LogoutSerializer, LoginSerializer, VerifyEmailSerializer
 import random
 from django.conf import settings
 from django.core.mail import send_mail
+
 
 class RegisterView(generics.GenericAPIView):
     """
@@ -44,9 +46,53 @@ class ProfileView(generics.RetrieveUpdateAPIView):
     """
     프로필 조회 및 수정 View.
     """
-    queryset = UserProfile.objects.all()
-    serializer_class = ProfileSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = ExtendedProfileSerializer
+    permission_classes = [permissions.AllowAny]  # 일단 인증 비활성화했음, 추후에 IsAuthenticated로 변경?
+
+    def get_queryset(self):
+        """
+        인증된 사용자에 해당하는 UserProfile만 반환.
+        """
+        return UserProfile.objects.none()  # 테스트용: 빈 QuerySet 반환
+        # return UserProfile.objects.filter(user=self.request.user) # 실제 사용 시 이렇게 사용(예시)
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+        Mock 데이터를 반환.
+        """
+        mock_data = {
+            "nickname": "mocktest_user",
+            "last_name": "Ran",
+            "first_name": "Choi",
+            "email": "mocktest@example.com",
+            "profile_image": "default_profile.jpeg"
+        }
+        return Response(mock_data)
+
+        # 실제 사용 시 이렇게 사용(예시)
+        # try:
+        #     user = request.user
+        #     user_profile = user.userprofile  # One-to-One 관계로 연결된 UserProfile
+        #     serializer = self.get_serializer(user_profile)
+        #     return Response(serializer.data, status=status.HTTP_200_OK)
+        # except UserProfile.DoesNotExist:
+        #     return Response({"error": "User profile not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    def update(self, request, *args, **kwargs):
+        """
+        Mock 업데이트 응답.
+        """
+        return Response({"message": "Profile updated successfully"}, status=200)
+
+        # 실제 사용 시 이렇게 사용(예시)
+        # try:
+        #     user_profile = request.user.userprofile
+        #     serializer = self.get_serializer(user_profile, data=request.data, partial=True)
+        #     serializer.is_valid(raise_exception=True)
+        #     serializer.save()
+        #     return Response(serializer.data, status=status.HTTP_200_OK)
+        # except UserProfile.DoesNotExist:
+        #     return Response({"error": "User profile not found"}, status=status.HTTP_404_NOT_FOUND)
 
 class UserStatsView(generics.RetrieveAPIView):
     """

--- a/back/transcendence/urls.py
+++ b/back/transcendence/urls.py
@@ -29,4 +29,5 @@ urlpatterns = [
     path(getSecretValue('back/BACK_API_FRIENDS'), include('friends.urls')),
     # path(getSecretValue('back/BACK_API_VAULT'), views.get_vault_data, name='get_vault_data'),
     path('api/vault/', views.get_vault_data, name='get_vault_data'),
+    path('api/accounts/', include('accounts.urls')),
 ]

--- a/front/src/auth/authProvider.js
+++ b/front/src/auth/authProvider.js
@@ -10,11 +10,16 @@ const Auth = {
             const authUrl = await getSecretValue('front/FRONT_API_ACCOUNTS_AUTH');
             const instance = await createAxiosInstance();
             console.log(authUrl);
-            const res = await instance.get(authUrl);
-            if (res.status === 200) {
-                this.isAuth = true;
-                this.user = JSON.parse(localStorage.getItem('user'));
-            }
+            // const res = await instance.get(authUrl);
+            // if (res.status === 200) {
+            //     this.isAuth = true;
+            //     this.user = JSON.parse(localStorage.getItem('user'));
+            // }
+
+            // 개발 환경 로직 추가, 추후 삭제하고 위의 주석된 코드 사용!!
+            console.warn('Auth check bypassed for development.');
+            this.isAuth = true; // 강제로 인증된 상태 설정
+            this.user = JSON.parse(localStorage.getItem('user')) || { username: 'dev_user' };
         } catch {
             console.log('Failed to check auth');
             this.isAuth = false;

--- a/front/src/page/editProfile.js
+++ b/front/src/page/editProfile.js
@@ -1,7 +1,8 @@
 import { loadCSS } from "../utils/loadcss";
 import { language } from "../utils/language";
+import { createAxiosInstance } from "../utils/axiosInterceptor";
 
-export function loadEditProfile() {
+export async function loadEditProfile() {
   loadCSS("../styles/editProfile.css");
   const languageKey = localStorage.getItem("selectedLanguage");
   const html = `
@@ -23,6 +24,10 @@ export function loadEditProfile() {
             <div class="form-section">
                 <form class="edit-profile-form">
                     <div class="form-group">
+                        <label class="form-label">${language[languageKey]["Email"]}</label>
+                        <p id="edit-profile-email" class="fixed-text"></p>
+                    </div>
+                    <div class="form-group">
                         <label class="form-label">${language[languageKey]["Nickname"]}</label>
                         <input type="text" id="nickname" class="form-input">
                     </div>
@@ -34,14 +39,10 @@ export function loadEditProfile() {
                         <label class="form-label">${language[languageKey]["FirstName"]}</label>
                         <input type="text" id="firstName" class="form-input">
                     </div>
-                    <div class="form-group">
-                        <label class="form-label">${language[languageKey]["Email"]}</label>
-                        <input type="text"  class="form-input">
-                    </div>
                 </form>
                 <div class="form-buttons">
                     <button type="button" class="edit-profile-cancel-btn">${language[languageKey]["DeleteAccount"]}</button>
-                    <button type="submit" class="edit-profile-save-btn">${language[languageKey]["Save"]}</button>
+                    <button type="submit" id="saveProfileBtn" class="edit-profile-save-btn">${language[languageKey]["Save"]}</button>
                 </div>
             </div>
         </div>
@@ -49,11 +50,59 @@ export function loadEditProfile() {
 
   document.getElementById("app").innerHTML = html;
 
-  // JavaScript 로직
   const profileImage = document.getElementById("profileImage");
   const deleteImageBtn = document.getElementById("deleteImageBtn");
   const imageUpload = document.getElementById("imageUpload");
+  const saveProfileBtn = document.getElementById("saveProfileBtn");
 
+  // Axios 인스턴스 생성
+  const axios = await createAxiosInstance();
+
+  // 유저 정보 데이터 로드 (이메일, 성, 이름, 닉네임, 프로필 이미지)
+  async function loadProfileData() {
+    try {
+      const response = await axios.get("/accounts/profile/");
+      const data = response.data;
+
+      // Mock 데이터 기반 유저 정보 업데이트
+      document.getElementById("nickname").value = data.nickname || "";
+      document.getElementById("lastName").value = data.last_name || "";
+      document.getElementById("firstName").value = data.first_name || "";
+      document.getElementById("edit-profile-email").textContent = data.email || "";
+      if (data.profile_image) {
+        profileImage.src = data.profile_image;
+      } else {
+        profileImage.src = "default_profile.jpeg";
+      }
+    } catch (error) {
+      console.error("Failed to load profile data:", error);
+      alert(language[languageKey]["ErrorLoadingProfile"]);
+    }
+  }
+
+  loadProfileData();
+
+  // 프로필 저장 버튼 클릭 시
+  saveProfileBtn.addEventListener("click", async (event) => {
+    event.preventDefault();
+    const formData = new FormData();
+    formData.append("nickname", document.getElementById("nickname").value);
+    formData.append("last_name", document.getElementById("lastName").value);
+    formData.append("first_name", document.getElementById("firstName").value);
+    if (imageUpload.files[0]) {
+      formData.append("profile_image", imageUpload.files[0]);
+    }
+
+    try {
+      await axios.put("/accounts/profile/", formData);
+      alert(language[languageKey]["ProfileUpdated"]);
+    } catch (error) {
+      console.error("Failed to update profile:", error);
+      alert(language[languageKey]["ErrorUpdatingProfile"]);
+    }
+  });
+
+  // 이미지 업로드
   imageUpload.addEventListener("change", (event) => {
     const file = event.target.files[0];
     if (file) {
@@ -66,18 +115,9 @@ export function loadEditProfile() {
     }
   });
 
+  // 이미지 초기화
   deleteImageBtn.addEventListener("click", () => {
     profileImage.src = "default_profile.jpeg";
-  });
-
-  const formInputs = document.querySelectorAll(".form-input");
-  formInputs.forEach((input) => {
-    input.addEventListener("focus", (e) => {
-      e.target.classList.add("active");
-    });
-
-    input.addEventListener("blur", (e) => {
-      e.target.classList.remove("active");
-    });
+    imageUpload.value = null;
   });
 }

--- a/front/src/page/login.js
+++ b/front/src/page/login.js
@@ -37,7 +37,7 @@ export function loadLogin() {
         <div class="social-login">
           <button id="social-login" class="social-btn">
             <a href="/42" data-router-link>
-              <img src="/42_logo_white.png" alt="42" class="login-btn-42logo">${language[languageKey]["SocialLogin"]}
+              <img src="/42_logo_white.png" alt="42" class="login-btn-42logo">${language[languageKey]["socialLogin"]}
             </a>
           </button>
         </div>

--- a/front/src/utils/language.js
+++ b/front/src/utils/language.js
@@ -51,6 +51,8 @@ export const language = {
       Email: "이메일",
       DeleteAccount: "탈퇴하기",
       Save: "저장하기",
+      ProfileUpdated: "프로필이 성공적으로 변경 되었습니다.",
+      ErrorUpdatingProfile: "프로필 변경 중 오류가 발생했습니다.",
   
       //loadChangePassword
       ChangePassword: "비밀번호 변경",
@@ -149,6 +151,8 @@ export const language = {
       Email: "Email",
       DeleteAccount: "Delete Account",
       Save: "Save",
+      ProfileUpdated: "Your profile has been successfully updated.",
+      ErrorUpdatingProfile: "An error occurred while updating profile.",
   
       //loadChangePassword
       ChangePassword: "Change Password",
@@ -247,6 +251,8 @@ export const language = {
       Email: "Email",
       DeleteAccount: "Supprimer le compte",
       Save: "Enregistrer",
+      ProfileUpdated: "Votre profil a été mis à jour avec succès.",
+      ErrorUpdatingProfile: "Une erreur s'est produite lors de la mise à jour de votre profil.",
   
       //loadChangePassword
       ChangePassword: "Changer le mot de passe",

--- a/front/styles/editProfile.css
+++ b/front/styles/editProfile.css
@@ -124,7 +124,7 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   font-size: 0.9rem;
-  color: #ccc;
+  color: #888;
   transition: all 0.3s ease;
 }
 
@@ -132,6 +132,12 @@
   border-color: #ee532c;
   outline: none;
   color: #333;
+}
+
+#edit-profile-email {
+  cursor: not-allowed;
+  color: #666;
+  font-size: .9rem;
 }
 
 /* 버튼 섹션 */


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #124 

## ✅ What Did You Do
- [x] editProfile.js에 프로필 정보 수정 페이지 이메일, 프로필 사진, 성, 이름 정보 API 연동

***

## 🎸 ETC

로그인이 안되는 문제로 로그인 한 채로 테스트는 못해본 상태.
추후 목데이터 없애고 DB 연결한 뒤 테스트 필요!!!

‼️ API 검증 테스트 했던 방식 기록 (확실치 않아서) ‼️

1. back/acconts/views.py의 ProfileView에 목데이터 선언
2. 터미널에서 api 호출 테스트 해보기 (curl -k -X GET https://localhost/api/accounts/profile/
-H "Content-Type: application/json")
3. 프론트에 연결 (나중에 목데이터 없애고 실제 DB에서 계정 정보 끌어와도 editProfile.js 코드 수정없이 작동하게끔)
4. /edit_profile 페이지 화면에 실제로 렌더링 되는지 확인