### PR TITLE
fix/#148 front dockerfile 순서 조정

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -2,15 +2,11 @@ FROM node:18
 
 WORKDIR /usr/src/app
 
-# package*.json 파일들을 복사
-COPY package*.json ./
+COPY . .
 
 # 개발 의존성을 포함한 모든 의존성 설치
-RUN npm ci
 RUN npm install -g vite
-
-# 나머지 소스 코드 복사
-COPY . .
+RUN npm install
 
 # 포트 설정
 EXPOSE 5173

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,15 +1,13 @@
 FROM node:18
-
 WORKDIR /usr/src/app
 
+# 소스 코드 복사
 COPY . .
 
 # 개발 의존성을 포함한 모든 의존성 설치
 RUN npm install -g vite
-RUN npm install
 
 # 포트 설정
 EXPOSE 5173
 
-# 개발 서버 실행
-CMD ["npm", "run", "dev"]
+ENTRYPOINT ["./setup.sh"]

--- a/front/setup.sh
+++ b/front/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+npm install
+npm run dev -- --host


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #148

## ✅ What Did You Do
- [x] COPY와 인스톨 순서를 변경함
- [x] 설치 스크립트를 따로 생성함
***

## 🎸 ETC
1. front Dockerfile에서 npm install이후 COPY를 진행하여 모듈이 사라지는 문제가 있음.
2. npm install -g vite로 vite를 전역 설치해야하는 것은 이전에 왜 문제가 없었는지 모르겠음. 현재는 vite를 따로 설치하지 않으면 컨테이너에서 1번 프로세스로 스크립트 자체가 실행되지 않음
3. 설치를 스크립트로 진행하지 않고 Dockerfile RUN 명령어로 수행하면 씹히는 문제가 있음